### PR TITLE
API authentication

### DIFF
--- a/src/app/api/chat-logs/[id]/route.ts
+++ b/src/app/api/chat-logs/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import { getChatlogById } from "@/server/db/actions/ChatlogAction";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 
@@ -7,6 +8,12 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await context.params; // Await params before accessing id
   try {
     const chatlog = await getChatlogById(id);
@@ -16,7 +23,23 @@ export async function GET(
         { status: HTTP_STATUS_CODE.NOT_FOUND },
       );
     }
-    return NextResponse.json(chatlog, { status: HTTP_STATUS_CODE.OK });
+    // Only allow: Admin/SuperAdmin, or participant (student/driver matches userId)
+    if (
+      user.type === "Admin" ||
+      user.type === "SuperAdmin" ||
+      (user.type === "Student" &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (chatlog as any).student?._id?.toString() === user.userId) ||
+      (user.type === "Driver" &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (chatlog as any).driver?._id?.toString() === user.userId)
+    ) {
+      return NextResponse.json(chatlog, { status: HTTP_STATUS_CODE.OK });
+    }
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
   } catch (error) {
     return NextResponse.json(
       { error: "Failed to fetch chatlog" },

--- a/src/app/api/chat-logs/route.ts
+++ b/src/app/api/chat-logs/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import { getChatlogs } from "@/server/db/actions/ChatlogAction";
 import { isValidObjectId } from "mongoose";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
@@ -6,6 +7,12 @@ import { HTTP_STATUS_CODE } from "@/utils/consts";
 // GET /api/chat-logs
 // Retrieves chatlogs with optional filters
 export async function GET(req: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const url = new URL(req.url);
   const filters = {
     studentId: url.searchParams.get("studentId"),
@@ -51,6 +58,21 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(
       { error: "Invalid endDate" },
       { status: HTTP_STATUS_CODE.BAD_REQUEST },
+    );
+  }
+
+  // Only allow: Admin/SuperAdmin, or participant (studentId/driverId matches userId)
+  if (
+    user.type !== "Admin" &&
+    user.type !== "SuperAdmin" &&
+    !(
+      (user.type === "Student" && filters.studentId === user.userId) ||
+      (user.type === "Driver" && filters.driverId === user.userId)
+    )
+  ) {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
     );
   }
 

--- a/src/app/api/locations/[id]/route.ts
+++ b/src/app/api/locations/[id]/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import Location from "@/server/db/models/LocationModel";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
+import { getUserFromRequest } from "@/utils/authUser";
 
 // GET /api/locations/:id
 export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
+  try {
+    await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await context.params; // Await params before accessing id
   try {
     const location = await Location.findById(id);
@@ -31,6 +37,18 @@ export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
+  }
   const { id } = await context.params; // Await params before accessing id
   try {
     const location = await Location.findById(id);

--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -6,11 +6,16 @@ import {
 import { locationSchema } from "@/utils/types";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 import { LocationAlreadyExistsException } from "@/utils/exceptions/location";
-import { EmailTemplates } from "@/server/db/actions/EmailAction";
+import { getUserFromRequest } from "@/utils/authUser";
 
 // GET /api/locations
 // Retrieves all locations
 export async function GET() {
+  try {
+    await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const locations = await getLocations();
 
@@ -29,6 +34,18 @@ export async function GET() {
 // POST /api/locations
 // Creates a new location
 export async function POST(request: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
+  }
   try {
     const body = await request.json();
     const parsed = locationSchema.safeParse(body);

--- a/src/app/api/routes/[id]/route.ts
+++ b/src/app/api/routes/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import mongoose from "mongoose";
 import { getRouteById, deleteRouteById } from "@/server/db/actions/RouteAction";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
@@ -7,6 +8,12 @@ export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
   if (!mongoose.Types.ObjectId.isValid(id)) {
     return NextResponse.json(
@@ -22,7 +29,22 @@ export async function GET(
         { status: HTTP_STATUS_CODE.NOT_FOUND },
       );
     }
-    return NextResponse.json(route, { status: HTTP_STATUS_CODE.OK });
+    // Only allow: Admin/SuperAdmin, or owner (student._id or driver._id matches userId)
+    if (
+      user.type === "Admin" ||
+      user.type === "SuperAdmin" ||
+      (route.student &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (route.student as any)._id?.toString() === user.userId) ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (route.driver && (route.driver as any)._id?.toString() === user.userId)
+    ) {
+      return NextResponse.json(route, { status: HTTP_STATUS_CODE.OK });
+    }
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
   } catch (e) {
     return NextResponse.json(
       { error: "Internal server error" },
@@ -35,6 +57,18 @@ export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
+  }
   const { id } = await params;
   if (!mongoose.Types.ObjectId.isValid(id)) {
     return NextResponse.json(

--- a/src/app/api/routes/cancel/route.ts
+++ b/src/app/api/routes/cancel/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import mongoose from "mongoose";
-import { cancelRoute } from "@/server/db/actions/RouteAction";
+import { cancelRoute, getRouteById } from "@/server/db/actions/RouteAction";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 
 export async function POST(request: NextRequest) {
+  let userId, type;
+  try {
+    const user = await getUserFromRequest();
+    userId = user.userId;
+    type = user.type;
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const body = await request.json();
     const { routeId } = body;
@@ -19,7 +28,46 @@ export async function POST(request: NextRequest) {
         { status: HTTP_STATUS_CODE.BAD_REQUEST },
       );
     }
-    const updated = await cancelRoute(routeId);
+    const route = await getRouteById(routeId);
+    if (!route) {
+      return NextResponse.json(
+        { error: "Route not found" },
+        { status: HTTP_STATUS_CODE.NOT_FOUND },
+      );
+    }
+    // Ownership/role check
+    if (type === "Student") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((route.student as any)?._id?.toString() !== userId) {
+        return NextResponse.json(
+          { error: "Forbidden" },
+          { status: HTTP_STATUS_CODE.FORBIDDEN },
+        );
+      }
+    } else if (type === "Driver") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((route.driver as any)?._id?.toString() !== userId) {
+        return NextResponse.json(
+          { error: "Forbidden" },
+          { status: HTTP_STATUS_CODE.FORBIDDEN },
+        );
+      }
+    } else if (type !== "Admin" && type !== "SuperAdmin") {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: HTTP_STATUS_CODE.FORBIDDEN },
+      );
+    }
+    // Set cancellation status based on caller type
+    let cancelStatus;
+    if (type === "Student") {
+      cancelStatus = "Cancelled by Student";
+    } else if (type === "Driver") {
+      cancelStatus = "Cancelled by Driver";
+    } else {
+      cancelStatus = "Cancelled by Admin";
+    }
+    const updated = await cancelRoute(routeId, cancelStatus);
     if (!updated) {
       return NextResponse.json(
         { error: "Route not found" },

--- a/src/app/api/routes/complete/route.ts
+++ b/src/app/api/routes/complete/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import mongoose from "mongoose";
-import { completeRoute } from "@/server/db/actions/RouteAction";
+import { completeRoute, getRouteById } from "@/server/db/actions/RouteAction";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 
 export async function POST(request: NextRequest) {
+  let userId, type;
+  try {
+    const user = await getUserFromRequest();
+    userId = user.userId;
+    type = user.type;
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const body = await request.json();
     const { routeId } = body;
@@ -17,6 +26,27 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: "Invalid routeId" },
         { status: HTTP_STATUS_CODE.BAD_REQUEST },
+      );
+    }
+    if (type === "Driver") {
+      const route = await getRouteById(routeId);
+      if (!route) {
+        return NextResponse.json(
+          { error: "Route not found" },
+          { status: HTTP_STATUS_CODE.NOT_FOUND },
+        );
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((route.driver as any)?._id?.toString() !== userId) {
+        return NextResponse.json(
+          { error: "Forbidden" },
+          { status: HTTP_STATUS_CODE.FORBIDDEN },
+        );
+      }
+    } else if (type !== "Admin" && type !== "SuperAdmin") {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: HTTP_STATUS_CODE.FORBIDDEN },
       );
     }
     const updated = await completeRoute(routeId);

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import mongoose from "mongoose";
 import {
   createRoute,
@@ -14,6 +15,12 @@ import {
 import { internalErrorPayload } from "@/utils/apiError";
 
 export async function GET(req: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const { searchParams } = new URL(req.url);
     const id = searchParams.get("id");
@@ -33,7 +40,22 @@ export async function GET(req: NextRequest) {
           { status: HTTP_STATUS_CODE.NOT_FOUND },
         );
       }
-      return NextResponse.json(route, { status: HTTP_STATUS_CODE.OK });
+      // Only allow: Admin/SuperAdmin, or owner (student._id or driver._id matches userId)
+      if (
+        user.type === "Admin" ||
+        user.type === "SuperAdmin" ||
+        (route.student &&
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (route.student as any)._id?.toString() === user.userId) ||
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (route.driver && (route.driver as any)._id?.toString() === user.userId)
+      ) {
+        return NextResponse.json(route, { status: HTTP_STATUS_CODE.OK });
+      }
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: HTTP_STATUS_CODE.FORBIDDEN },
+      );
     }
 
     // Get all routes with optional filters: ?student=ID | ?driver=ID | ?start_time=<time> | ?end_time=<time>
@@ -75,13 +97,34 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    const routes = await getRoutes({
-      student: student ?? undefined,
-      driver: driver ?? undefined,
-      start_time: startDate,
-      end_time: endDate,
-    });
-    return NextResponse.json(routes, { status: HTTP_STATUS_CODE.OK });
+    // Only allow: Admin/SuperAdmin, or filter by own userId if Student/Driver
+    if (user.type === "Admin" || user.type === "SuperAdmin") {
+      const routes = await getRoutes({
+        student: student ?? undefined,
+        driver: driver ?? undefined,
+        start_time: startDate,
+        end_time: endDate,
+      });
+      return NextResponse.json(routes, { status: HTTP_STATUS_CODE.OK });
+    } else if (user.type === "Student") {
+      const routes = await getRoutes({
+        student: user.userId,
+        start_time: startDate,
+        end_time: endDate,
+      });
+      return NextResponse.json(routes, { status: HTTP_STATUS_CODE.OK });
+    } else if (user.type === "Driver") {
+      const routes = await getRoutes({
+        driver: user.userId,
+        start_time: startDate,
+        end_time: endDate,
+      });
+      return NextResponse.json(routes, { status: HTTP_STATUS_CODE.OK });
+    }
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
   } catch (e) {
     if (
       e instanceof RouteAlreadyExistsException ||
@@ -97,6 +140,12 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const body = await request.json();
     const parsed = createRouteSchema.safeParse(body);
@@ -106,6 +155,12 @@ export async function POST(request: NextRequest) {
       });
     }
 
+    if (!(user.type === "Student" && user.userId === parsed.data.student)) {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: HTTP_STATUS_CODE.FORBIDDEN },
+      );
+    }
     // Driver and vehicle must not be set on create; use POST /api/routes/schedule instead.
     if (body.driver != null || body.vehicle != null) {
       return NextResponse.json(

--- a/src/app/api/routes/schedule/route.ts
+++ b/src/app/api/routes/schedule/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import mongoose from "mongoose";
 import { scheduleRoute } from "@/server/db/actions/RouteAction";
 import { RouteReferenceNotFoundException } from "@/utils/exceptions/route";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 
 export async function POST(request: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const body = await request.json();
     const { routeId, driverId, vehicleId } = body;
@@ -22,6 +29,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: "Invalid ObjectId(s)" },
         { status: HTTP_STATUS_CODE.BAD_REQUEST },
+      );
+    }
+    // Only allow: Admin, SuperAdmin
+    if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: HTTP_STATUS_CODE.FORBIDDEN },
       );
     }
     const updated = await scheduleRoute(routeId, driverId, vehicleId);

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import mongoose from "mongoose";
 import { getUserById, deleteUser } from "@/server/db/actions/UserAction";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
@@ -8,6 +9,12 @@ export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  let authUser;
+  try {
+    authUser = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
   if (!mongoose.Types.ObjectId.isValid(id)) {
     return NextResponse.json(
@@ -23,12 +30,23 @@ export async function GET(
         { status: HTTP_STATUS_CODE.NOT_FOUND },
       );
     }
-    const userObj = user as Record<string, unknown> & {
-      _id: { toString(): string };
-    };
+    // Only allow: Admin/SuperAdmin, or self
+    if (
+      authUser.type === "Admin" ||
+      authUser.type === "SuperAdmin" ||
+      user._id?.toString() === authUser.userId
+    ) {
+      const userObj = user as Record<string, unknown> & {
+        _id: { toString(): string };
+      };
+      return NextResponse.json(
+        { ...userObj, _id: userObj._id.toString() },
+        { status: HTTP_STATUS_CODE.OK },
+      );
+    }
     return NextResponse.json(
-      { ...userObj, _id: userObj._id.toString() },
-      { status: HTTP_STATUS_CODE.OK },
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
     );
   } catch (e) {
     return NextResponse.json(internalErrorPayload(e), {
@@ -41,6 +59,12 @@ export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  let authUser;
+  try {
+    authUser = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
   if (!mongoose.Types.ObjectId.isValid(id)) {
     return NextResponse.json(
@@ -49,6 +73,23 @@ export async function DELETE(
     );
   }
   try {
+    const user = await getUserById(id);
+    if (!user) {
+      return NextResponse.json(
+        { error: "User not found" },
+        { status: HTTP_STATUS_CODE.NOT_FOUND },
+      );
+    }
+    if (
+      (authUser.type !== "Admin" && authUser.type !== "SuperAdmin") ||
+      ((user.type === "Admin" || user.type === "SuperAdmin") &&
+        authUser.type !== "SuperAdmin")
+    ) {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: HTTP_STATUS_CODE.FORBIDDEN },
+      );
+    }
     const deleted = await deleteUser(id);
     if (!deleted) {
       return NextResponse.json(

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import { createUser, getUsers } from "@/server/db/actions/UserAction";
 import { baseUserSchema, studentSchema } from "@/utils/types/user";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
@@ -6,6 +7,18 @@ import { UserAlreadyExistsException } from "@/utils/exceptions/user";
 import { internalErrorPayload } from "@/utils/apiError";
 
 export async function GET(request: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
+  }
   try {
     const searchParams = request.nextUrl.searchParams;
     //so you can filter by the type of user
@@ -26,6 +39,18 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
+  }
   try {
     const body = await request.json();
     let parsed;
@@ -40,6 +65,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(parsed.error.format(), {
         status: HTTP_STATUS_CODE.BAD_REQUEST,
       });
+    }
+
+    if (
+      user.type !== "SuperAdmin" &&
+      (parsed.data.type == "Admin" || parsed.data.type == "SuperAdmin")
+    ) {
+      return NextResponse.json(
+        { error: "Forbidden" },
+        { status: HTTP_STATUS_CODE.FORBIDDEN },
+      );
     }
 
     const created = await createUser(parsed.data);

--- a/src/app/api/vehicles/[id]/route.ts
+++ b/src/app/api/vehicles/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import mongoose from "mongoose";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 import {
@@ -10,6 +11,11 @@ export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  try {
+    await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const { id } = await params;
   if (!mongoose.Types.ObjectId.isValid(id)) {
     return NextResponse.json(
@@ -38,6 +44,18 @@ export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
+  }
   const { id } = await params;
   if (!mongoose.Types.ObjectId.isValid(id)) {
     return NextResponse.json(

--- a/src/app/api/vehicles/route.ts
+++ b/src/app/api/vehicles/route.ts
@@ -1,10 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getUserFromRequest } from "@/utils/authUser";
 import { vehicleSchema } from "@/utils/types/vehicle";
 import { HTTP_STATUS_CODE } from "@/utils/consts";
 import { createVehicle, getVehicles } from "@/server/db/actions/VehicleAction";
 import { VehicleAlreadyExistsException } from "@/utils/exceptions/vehicle";
 
 export async function POST(req: NextRequest) {
+  let user;
+  try {
+    user = await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.type !== "Admin" && user.type !== "SuperAdmin") {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: HTTP_STATUS_CODE.FORBIDDEN },
+    );
+  }
   try {
     const body = await req.json();
     const parsed = vehicleSchema.safeParse(body);
@@ -35,6 +48,11 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET() {
+  try {
+    await getUserFromRequest();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const vehicles = await getVehicles();
     return NextResponse.json(vehicles);

--- a/src/server/db/actions/RouteAction.ts
+++ b/src/server/db/actions/RouteAction.ts
@@ -116,13 +116,17 @@ export async function completeRoute(routeId: string) {
   await route.save();
   return route.toObject();
 }
-export async function cancelRoute(routeId: string) {
+export async function cancelRoute(routeId: string, status?: string) {
   await connectMongoDB();
   const route = await RouteModel.findById(routeId);
   if (!route) {
     return null;
   }
-  route.status = RouteStatus.CancelledByStudent;
+  if (status && Object.values(RouteStatus).includes(status as RouteStatus)) {
+    route.status = status as RouteStatus;
+  } else {
+    route.status = RouteStatus.CancelledByStudent;
+  }
   await route.save();
   return route.toObject();
 }

--- a/src/utils/authUser.ts
+++ b/src/utils/authUser.ts
@@ -1,0 +1,19 @@
+import { auth } from "../auth";
+
+export type UserType = "Student" | "Driver" | "Admin" | "SuperAdmin";
+
+export interface AuthUser {
+  userId: string;
+  type: UserType;
+}
+
+export async function getUserFromRequest(): Promise<AuthUser> {
+  const session = await auth();
+  if (!session || !session.user || !session.user.id || !session.user.type) {
+    throw new Error("Invalid session or missing user info");
+  }
+  return {
+    userId: session.user.id,
+    type: session.user.type as UserType,
+  };
+}


### PR DESCRIPTION
- There's something messed up in the TypeScript of returned embedded schemas. When I get a Route, the TypeScript student property is of type IBaseUser so it doesn't show the _id as a valid property. I just used any for now, I'm not sure how TypeScript works with Mongoose
- Typescript doesn't show any of the properties for ChatLog when returned from getChatlogById, might be because there is no typescript annotation when doing new Schema? I'm not really sure though.
- To call auth, I needed to change every single endpoint to use NextAPiRequest and NextApiResponse, which ended up changing way more lines that seems necessary. I'm not sure if there's a better method.